### PR TITLE
Fix scroll layout; add conflict-safe saves, wikilink autocomplete, ta…

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -88,7 +88,7 @@ kbd {
 
 /* ---------- welcome ---------- */
 .welcome {
-  height: 100%;
+  height: 100dvh;
   display: grid;
   place-items: center;
   overflow: auto;
@@ -130,10 +130,15 @@ kbd {
 .welcome-points code { font-family: var(--font-mono); }
 
 /* ---------- app layout ---------- */
+/* The single grid row must be capped at the viewport (minmax(0, 1fr), not the
+   auto-sized implicit row) and every scroll container's ancestors need
+   min-height: 0 — otherwise content grows the row past the viewport and gets
+   clipped by body{overflow:hidden}, making nothing scrollable. */
 .app {
   display: grid;
   grid-template-columns: var(--sidebar-w) 1fr;
-  height: 100%;
+  grid-template-rows: minmax(0, 1fr);
+  height: 100dvh;
 }
 
 .sidebar {
@@ -142,6 +147,7 @@ kbd {
   display: flex;
   flex-direction: column;
   min-width: 0;
+  min-height: 0;
 }
 .sidebar-header {
   padding: 12px;
@@ -175,6 +181,25 @@ kbd {
 .search-row input:focus { border-color: var(--accent); }
 .sidebar-actions { display: flex; gap: 6px; align-items: center; }
 .sidebar-actions .btn { flex: 1; }
+
+.tag-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  max-height: 110px;
+  overflow-y: auto;
+}
+.tag-chip {
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-dim);
+  font-size: 0.76rem;
+  padding: 1px 9px;
+}
+.tag-chip:hover { border-color: var(--accent); color: var(--text); }
+.tag-chip.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+.tag-chip .tag-count { opacity: 0.65; margin-left: 3px; }
 
 .note-list { flex: 1; overflow-y: auto; padding: 6px; }
 .note-item {
@@ -227,7 +252,7 @@ kbd {
 }
 
 /* ---------- main / editor ---------- */
-.main { display: flex; flex-direction: column; min-width: 0; }
+.main { display: flex; flex-direction: column; min-width: 0; min-height: 0; }
 .empty-state {
   flex: 1;
   display: grid;
@@ -274,6 +299,18 @@ kbd {
 }
 .toggle-btn.active { background: var(--accent); color: #fff; }
 
+.conflict-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--mark);
+  background: color-mix(in srgb, var(--mark) 14%, var(--bg-raised));
+  font-size: 0.85rem;
+}
+.conflict-bar span { flex: 1; min-width: 200px; }
+
 .meta-bar {
   display: flex;
   flex-wrap: wrap;
@@ -288,7 +325,10 @@ kbd {
   border: 1px solid var(--border);
   border-radius: 999px;
   padding: 1px 10px;
+  color: inherit;
+  font: inherit;
 }
+button.meta-tag:hover { border-color: var(--accent); color: var(--text); }
 
 .editor-split {
   flex: 1;
@@ -446,6 +486,38 @@ kbd {
 .hit-title { font-weight: 600; font-size: 0.93rem; }
 .hit-snippet { font-size: 0.8rem; color: var(--text-dim); margin-top: 3px; line-height: 1.5; }
 .hit-snippet mark { background: var(--mark); color: #3a3000; border-radius: 3px; padding: 0 2px; }
+
+/* ---------- wikilink autocomplete ---------- */
+.wl-autocomplete {
+  position: fixed;
+  z-index: 55;
+  min-width: 220px;
+  max-width: 340px;
+  max-height: 260px;
+  overflow-y: auto;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 14px 40px rgb(0 0 0 / 0.45);
+  padding: 4px;
+}
+.wl-autocomplete button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--text);
+  padding: 6px 10px;
+  font-size: 0.88rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wl-autocomplete button.selected { background: var(--accent); color: #fff; }
+.wl-autocomplete .wl-alias { color: var(--text-dim); font-size: 0.8em; margin-left: 6px; }
+.wl-autocomplete button.selected .wl-alias { color: rgb(255 255 255 / 0.8); }
 
 /* ---------- toast ---------- */
 .toast {

--- a/index.html
+++ b/index.html
@@ -58,8 +58,10 @@
         </div>
         <div class="sidebar-actions">
           <button id="btn-new-note" class="btn btn-primary btn-sm">+ New note</button>
+          <button id="btn-daily" class="btn btn-sm" title="Open today's daily note">📅 Today</button>
           <button id="btn-refresh" class="icon-btn" title="Rescan folder">↻</button>
         </div>
+        <div id="tag-bar" class="tag-bar" aria-label="Filter by tag" hidden></div>
       </header>
       <nav id="note-list" class="note-list" aria-label="Notes"></nav>
       <footer class="sidebar-footer">
@@ -86,6 +88,12 @@
             <button id="btn-delete-note" class="icon-btn danger" title="Delete note">🗑</button>
           </div>
         </header>
+
+        <div id="conflict-bar" class="conflict-bar" hidden>
+          <span>⚠️ This note changed on disk (edited elsewhere or synced). Which version do you want?</span>
+          <button id="btn-conflict-load" class="btn btn-sm">Load disk version</button>
+          <button id="btn-conflict-overwrite" class="btn btn-sm">Keep mine</button>
+        </div>
 
         <div id="meta-bar" class="meta-bar" hidden></div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -4,6 +4,7 @@ import * as db from './db.js';
 import * as fs from './fs.js';
 import { NoteIndex } from './search.js';
 import { parseFrontmatter, metaTags, renderMarkdown } from './markdown.js';
+import { attachWikilinkAutocomplete } from './autocomplete.js';
 
 // ------------------------------------------------------------------ state
 
@@ -14,7 +15,10 @@ const state = {
   index: new NoteIndex(),
   currentPath: null,
   currentText: '',
+  currentMtime: null,   // on-disk mtime when the note was last read/written
+  conflict: false,      // disk changed under a dirty editor; saves are blocked
   dirty: false,
+  tagFilter: null,      // active tag chip, or null for all notes
   blobUrls: [],         // object URLs owned by the current preview
   usingOpfs: false,
 };
@@ -28,6 +32,9 @@ const el = {
   fallbackNote: $('fallback-note'),
   workspaceName: $('workspace-name'), btnSwitch: $('btn-switch-workspace'),
   searchInput: $('search-input'), btnNew: $('btn-new-note'), btnRefresh: $('btn-refresh'),
+  btnDaily: $('btn-daily'), tagBar: $('tag-bar'),
+  conflictBar: $('conflict-bar'), btnConflictLoad: $('btn-conflict-load'),
+  btnConflictOverwrite: $('btn-conflict-overwrite'),
   noteList: $('note-list'), noteCount: $('note-count'), offlineBadge: $('offline-badge'),
   emptyState: $('empty-state'), editorPane: $('editor-pane'),
   noteTitle: $('note-title'), saveState: $('save-state'),
@@ -158,10 +165,18 @@ async function refreshWorkspace({ firstRun = false } = {}) {
     async (path) => (await fs.readNote(state.dirHandle, path)).text,
   );
   if (changed || firstRun) persistIndexSoon();
+  renderTagBar();
   renderNoteList();
-  if (state.currentPath && !state.notes.some((n) => n.path === state.currentPath)) {
+  const current = state.notes.find((n) => n.path === state.currentPath);
+  if (state.currentPath && !current) {
     closeNote();
-  } else if (state.currentPath) {
+  } else if (current) {
+    // The open note changed on disk (OS sync, another editor): follow it if the
+    // editor is clean, otherwise let the user pick a side.
+    if (state.currentMtime != null && current.lastModified !== state.currentMtime) {
+      if (state.dirty) setConflict(true);
+      else await reloadCurrentFromDisk();
+    }
     renderBacklinks();
   }
 }
@@ -195,9 +210,44 @@ Your notes are plain **Markdown** files.
 
 // ------------------------------------------------------------- note list
 
+function renderTagBar() {
+  const counts = new Map();
+  for (const doc of state.index.docs.values()) {
+    for (const t of doc.tags) counts.set(t, (counts.get(t) || 0) + 1);
+  }
+  if (state.tagFilter && !counts.has(state.tagFilter)) state.tagFilter = null;
+
+  el.tagBar.textContent = '';
+  el.tagBar.hidden = counts.size === 0;
+  const tags = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  for (const [tag, count] of tags) {
+    const chip = document.createElement('button');
+    chip.className = 'tag-chip' + (tag === state.tagFilter ? ' active' : '');
+    chip.textContent = `#${tag}`;
+    const n = document.createElement('span');
+    n.className = 'tag-count';
+    n.textContent = count;
+    chip.appendChild(n);
+    chip.addEventListener('click', () => setTagFilter(tag === state.tagFilter ? null : tag));
+    el.tagBar.appendChild(chip);
+  }
+}
+
+function setTagFilter(tag) {
+  state.tagFilter = tag;
+  renderTagBar();
+  renderNoteList();
+}
+
 function renderNoteList() {
   el.noteList.textContent = '';
+  let shown = 0;
   for (const note of state.notes) {
+    if (state.tagFilter) {
+      const doc = state.index.docs.get(note.path);
+      if (!doc || !doc.tags.includes(state.tagFilter)) continue;
+    }
+    shown++;
     const btn = document.createElement('button');
     btn.className = 'note-item' + (note.path === state.currentPath ? ' active' : '');
     btn.dataset.path = note.path;
@@ -216,23 +266,27 @@ function renderNoteList() {
     btn.addEventListener('click', () => { openNote(note.path); closeSidebarOnMobile(); });
     el.noteList.appendChild(btn);
   }
-  el.noteCount.textContent = `${state.notes.length} note${state.notes.length === 1 ? '' : 's'}`;
+  el.noteCount.textContent = state.tagFilter
+    ? `${shown} of ${state.notes.length} · #${state.tagFilter}`
+    : `${state.notes.length} note${state.notes.length === 1 ? '' : 's'}`;
 }
 
 // ------------------------------------------------------------ note editing
 
 async function openNote(path) {
   await flushSave();
-  let text;
+  let text, lastModified;
   try {
-    ({ text } = await fs.readNote(state.dirHandle, path));
+    ({ text, lastModified } = await fs.readNote(state.dirHandle, path));
   } catch (err) {
     toast(`Could not open note: ${err.message}`, { error: true });
     return;
   }
   state.currentPath = path;
   state.currentText = text;
+  state.currentMtime = lastModified;
   state.dirty = false;
+  setConflict(false);
 
   const note = state.notes.find((n) => n.path === path);
   el.noteTitle.value = note ? note.title : path.replace(/\.md$/i, '');
@@ -248,31 +302,57 @@ async function openNote(path) {
 function closeNote() {
   state.currentPath = null;
   state.currentText = '';
+  state.currentMtime = null;
   state.dirty = false;
+  setConflict(false);
   el.editorPane.hidden = true;
   el.emptyState.hidden = false;
   renderNoteList();
 }
 
 function setSaveState(mode) {
-  el.saveState.classList.toggle('dirty', mode === 'dirty');
-  el.saveState.textContent = { saved: 'saved', dirty: 'unsaved…', saving: 'saving…' }[mode] || '';
+  el.saveState.classList.toggle('dirty', mode === 'dirty' || mode === 'conflict');
+  el.saveState.textContent = {
+    saved: 'saved', dirty: 'unsaved…', saving: 'saving…', conflict: 'conflict',
+  }[mode] || '';
 }
 
-async function saveCurrentNote() {
-  if (!state.currentPath || !state.dirty) return;
+function setConflict(active) {
+  state.conflict = active;
+  el.conflictBar.hidden = !active;
+  if (active) setSaveState('conflict');
+}
+
+/**
+ * Save the current note, refusing to clobber a file that changed on disk
+ * since we read it (another device syncing, another editor). A conflict
+ * blocks autosave until the user picks a side via the conflict bar.
+ */
+async function saveCurrentNote({ force = false } = {}) {
+  if (!state.currentPath || !state.dirty || (state.conflict && !force)) return;
   const path = state.currentPath;
   const text = el.editor.value;
+
+  if (!force && state.currentMtime != null) {
+    const diskMtime = await fs.statNote(state.dirHandle, path);
+    if (diskMtime != null && diskMtime !== state.currentMtime) {
+      setConflict(true);
+      return;
+    }
+  }
+
   setSaveState('saving');
   try {
     await fs.writeNote(state.dirHandle, path, text);
     state.currentText = text;
+    state.currentMtime = await fs.statNote(state.dirHandle, path);
     state.dirty = false;
+    setConflict(false);
     setSaveState('saved');
     const note = state.notes.find((n) => n.path === path);
     const title = note ? note.title : path.replace(/\.md$/i, '');
-    state.index.upsert(path, title, text, Date.now());
-    if (note) note.lastModified = Date.now();
+    state.index.upsert(path, title, text, state.currentMtime ?? Date.now());
+    if (note) note.lastModified = state.currentMtime ?? Date.now();
     persistIndexSoon();
     renderBacklinks();
   } catch (err) {
@@ -282,6 +362,25 @@ async function saveCurrentNote() {
 }
 
 const autoSave = debounce(saveCurrentNote, 800);
+
+/** Replace the editor with the on-disk version of the current note. */
+async function reloadCurrentFromDisk() {
+  const path = state.currentPath;
+  if (!path) return;
+  try {
+    const { text, lastModified } = await fs.readNote(state.dirHandle, path);
+    state.currentText = text;
+    state.currentMtime = lastModified;
+    state.dirty = false;
+    el.editor.value = text;
+    setConflict(false);
+    setSaveState('saved');
+    renderPreview();
+    renderBacklinks();
+  } catch (err) {
+    toast(`Could not reload note: ${err.message}`, { error: true });
+  }
+}
 
 async function flushSave() {
   if (state.dirty) await saveCurrentNote();
@@ -303,6 +402,24 @@ async function createNote(title = 'Untitled', body = '') {
   await openNote(name);
   el.noteTitle.focus();
   el.noteTitle.select();
+}
+
+/** Open today's daily note (YYYY-MM-DD.md), creating it on first use. */
+async function openDailyNote() {
+  const now = new Date();
+  const pad = (n) => String(n).padStart(2, '0');
+  const title = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+  const path = fs.titleToFilename(title);
+  if (await fs.noteExists(state.dirHandle, path)) {
+    await openNote(path);
+    return;
+  }
+  const heading = now.toLocaleDateString(undefined, {
+    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+  });
+  await createNote(title, `---\ntags: [daily]\n---\n\n# ${heading}\n\n`);
+  el.editor.focus();
+  el.editor.selectionStart = el.editor.selectionEnd = el.editor.value.length;
 }
 
 async function deleteCurrentNote() {
@@ -349,7 +466,8 @@ async function renameCurrentNote() {
   }
   state.index.remove(state.currentPath);
   state.currentPath = newPath;
-  state.index.upsert(newPath, newTitle.replace(/\.md$/i, ''), el.editor.value, Date.now());
+  state.currentMtime = await fs.statNote(state.dirHandle, newPath);
+  state.index.upsert(newPath, newTitle.replace(/\.md$/i, ''), el.editor.value, state.currentMtime ?? Date.now());
   persistIndexSoon();
   await refreshWorkspace();
   toast('Note renamed');
@@ -382,10 +500,12 @@ function renderMetaBar(meta) {
     return;
   }
   for (const t of tags) {
-    const span = document.createElement('span');
-    span.className = 'meta-tag';
-    span.textContent = `#${t}`;
-    el.metaBar.appendChild(span);
+    const btn = document.createElement('button');
+    btn.className = 'meta-tag';
+    btn.textContent = `#${t}`;
+    btn.title = `Show notes tagged #${t}`;
+    btn.addEventListener('click', () => setTagFilter(t));
+    el.metaBar.appendChild(btn);
   }
   for (const [k, v] of extra) {
     const span = document.createElement('span');
@@ -545,12 +665,29 @@ function wireEvents() {
     await openWorkspacePicker();
   });
   el.btnNew.addEventListener('click', () => createNote());
+  el.btnDaily.addEventListener('click', openDailyNote);
   el.btnRefresh.addEventListener('click', () => refreshWorkspace());
   el.btnDelete.addEventListener('click', deleteCurrentNote);
 
+  el.btnConflictLoad.addEventListener('click', reloadCurrentFromDisk);
+  el.btnConflictOverwrite.addEventListener('click', () => saveCurrentNote({ force: true }));
+
+  // [[wikilink]] autocomplete fed by the live title/alias map.
+  attachWikilinkAutocomplete(el.editor, () => {
+    const candidates = [];
+    for (const doc of state.index.docs.values()) {
+      candidates.push({ label: doc.title, insert: doc.title });
+      for (const a of doc.aliases) {
+        candidates.push({ label: a, insert: a, hint: `→ ${doc.title}` });
+      }
+    }
+    candidates.sort((a, b) => a.label.localeCompare(b.label));
+    return candidates;
+  });
+
   el.editor.addEventListener('input', () => {
     state.dirty = el.editor.value !== state.currentText;
-    setSaveState(state.dirty ? 'dirty' : 'saved');
+    setSaveState(state.conflict ? 'conflict' : state.dirty ? 'dirty' : 'saved');
     renderPreview();
     if (state.dirty) autoSave();
   });

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -1,0 +1,157 @@
+// Wikilink autocomplete for the editor textarea.
+//
+// While the caret sits inside an unclosed [[...  a dropdown of matching note
+// titles/aliases appears at the caret. Enter/Tab inserts "Title]]"; arrows
+// navigate; Escape dismisses.
+
+const MAX_ITEMS = 8;
+
+// Style properties that affect text layout — copied onto the mirror div used
+// to locate the caret inside the textarea.
+const MIRROR_PROPS = [
+  'boxSizing', 'width', 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft',
+  'borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth',
+  'fontFamily', 'fontSize', 'fontWeight', 'fontStyle', 'letterSpacing',
+  'lineHeight', 'textTransform', 'wordSpacing', 'textIndent', 'whiteSpace',
+  'overflowWrap', 'tabSize',
+];
+
+/** Pixel coordinates of the caret inside a textarea, relative to the viewport. */
+function caretViewportPosition(textarea) {
+  const mirror = document.createElement('div');
+  const style = window.getComputedStyle(textarea);
+  for (const prop of MIRROR_PROPS) mirror.style[prop] = style[prop];
+  mirror.style.position = 'absolute';
+  mirror.style.visibility = 'hidden';
+  mirror.style.whiteSpace = 'pre-wrap';
+  mirror.style.overflowWrap = 'break-word';
+
+  mirror.textContent = textarea.value.slice(0, textarea.selectionStart);
+  const marker = document.createElement('span');
+  marker.textContent = '​';
+  mirror.appendChild(marker);
+  document.body.appendChild(mirror);
+
+  const rect = textarea.getBoundingClientRect();
+  const top = rect.top + (marker.offsetTop - textarea.scrollTop) + parseFloat(style.lineHeight || 20);
+  const left = rect.left + (marker.offsetLeft - textarea.scrollLeft);
+  mirror.remove();
+  return { top, left };
+}
+
+/**
+ * Wire autocomplete onto `textarea`.
+ * getCandidates() -> [{ label, insert, hint }] (already unfiltered; we filter).
+ */
+export function attachWikilinkAutocomplete(textarea, getCandidates) {
+  const box = document.createElement('div');
+  box.className = 'wl-autocomplete';
+  box.hidden = true;
+  document.body.appendChild(box);
+
+  let items = [];
+  let selected = 0;
+  let queryStart = -1; // index in the value just after "[["
+
+  function close() {
+    box.hidden = true;
+    items = [];
+    queryStart = -1;
+  }
+
+  function activeQuery() {
+    const pos = textarea.selectionStart;
+    const before = textarea.value.slice(0, pos);
+    const open = before.lastIndexOf('[[');
+    if (open === -1) return null;
+    const fragment = before.slice(open + 2);
+    // Bail if the link was closed or the fragment spans a newline/pipe.
+    if (/[\]\n|#]/.test(fragment)) return null;
+    return { start: open + 2, text: fragment };
+  }
+
+  function render() {
+    box.textContent = '';
+    items.forEach((item, i) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = item.label;
+      if (item.hint) {
+        const hint = document.createElement('span');
+        hint.className = 'wl-alias';
+        hint.textContent = item.hint;
+        btn.appendChild(hint);
+      }
+      if (i === selected) btn.classList.add('selected');
+      // mousedown so the textarea keeps focus
+      btn.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        pick(i);
+      });
+      box.appendChild(btn);
+    });
+  }
+
+  function pick(i) {
+    const item = items[i];
+    if (!item || queryStart === -1) return;
+    const end = textarea.selectionStart;
+    const after = textarea.value.slice(end);
+    const closing = after.startsWith(']]') ? '' : ']]';
+    textarea.value = textarea.value.slice(0, queryStart) + item.insert + closing + textarea.value.slice(end);
+    const caret = queryStart + item.insert.length + closing.length + (closing ? 0 : 2);
+    textarea.selectionStart = textarea.selectionEnd = caret;
+    close();
+    textarea.dispatchEvent(new Event('input'));
+    textarea.focus();
+  }
+
+  function update() {
+    const q = activeQuery();
+    if (!q) { close(); return; }
+    const needle = q.text.toLowerCase();
+    const all = getCandidates();
+    const starts = [];
+    const contains = [];
+    for (const c of all) {
+      const hay = c.label.toLowerCase();
+      if (needle === '') starts.push(c);
+      else if (hay.startsWith(needle)) starts.push(c);
+      else if (hay.includes(needle)) contains.push(c);
+    }
+    items = [...starts, ...contains].slice(0, MAX_ITEMS);
+    if (items.length === 0) { close(); return; }
+    queryStart = q.start;
+    selected = 0;
+    render();
+    const { top, left } = caretViewportPosition(textarea);
+    box.hidden = false;
+    const boxWidth = Math.min(340, window.innerWidth - 20);
+    box.style.top = `${Math.min(top + 4, window.innerHeight - box.offsetHeight - 10)}px`;
+    box.style.left = `${Math.min(left, window.innerWidth - boxWidth - 10)}px`;
+  }
+
+  textarea.addEventListener('input', update);
+  textarea.addEventListener('click', () => { if (!box.hidden) update(); });
+  textarea.addEventListener('blur', () => setTimeout(close, 100));
+  textarea.addEventListener('keydown', (e) => {
+    if (box.hidden) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      selected = (selected + 1) % items.length;
+      render();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      selected = (selected - 1 + items.length) % items.length;
+      render();
+    } else if (e.key === 'Enter' || e.key === 'Tab') {
+      e.preventDefault();
+      pick(selected);
+    } else if (e.key === 'Escape') {
+      e.stopPropagation();
+      close();
+    }
+  });
+
+  return { close };
+}

--- a/js/fs.js
+++ b/js/fs.js
@@ -95,6 +95,18 @@ export async function readNote(dirHandle, path) {
   return { text: await file.text(), lastModified: file.lastModified };
 }
 
+/** Current on-disk mtime of a note, or null if it can't be read. */
+export async function statNote(dirHandle, path) {
+  try {
+    const { dir, base } = await resolveParent(dirHandle, path);
+    const fileHandle = await dir.getFileHandle(base);
+    const file = await fileHandle.getFile();
+    return file.lastModified;
+  } catch {
+    return null;
+  }
+}
+
 export async function writeNote(dirHandle, path, text) {
   const { dir, base } = await resolveParent(dirHandle, path, { create: true });
   const fileHandle = await dir.getFileHandle(base, { create: true });

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,7 @@
 // MiNotes service worker — caches the app shell so the app runs fully offline.
 // Notes themselves never pass through here; they live on the local file system.
 
-const CACHE_NAME = 'minotes-shell-v1';
+const CACHE_NAME = 'minotes-shell-v2';
 
 const SHELL = [
   './',
@@ -9,6 +9,7 @@ const SHELL = [
   './manifest.webmanifest',
   './css/app.css',
   './js/app.js',
+  './js/autocomplete.js',
   './js/db.js',
   './js/fs.js',
   './js/markdown.js',


### PR DESCRIPTION
…gs, daily notes

- Fix scrolling everywhere: the app grid's implicit row grew with content and body{overflow:hidden} clipped it; pin the row to the viewport (minmax(0,1fr) + 100dvh) and add min-height:0 to grid/flex children
- Conflict-safe saves: stat the file before each write; if it changed on disk (OS sync, another editor) block the save and offer Load-disk / Keep-mine; clean editors silently follow disk changes on refresh
- Wikilink autocomplete: typing [[ opens a caret-positioned dropdown of titles and aliases with keyboard navigation
- Tag browser: sidebar chips with counts filter the note list; meta-bar tags are clickable
- Daily notes: Today button opens/creates YYYY-MM-DD.md
- Bump service worker cache to v2 and cache the new module


Claude-Session: https://claude.ai/code/session_01DCLqojSC5iSW7vSjymsZBZ