### PR TITLE
⚡ Bolt: Parallelize file stats for faster workspace load

### DIFF
--- a/js/fs.js
+++ b/js/fs.js
@@ -53,28 +53,36 @@ export async function listNotes(dirHandle) {
 }
 
 async function walk(dirHandle, prefix, out) {
+  // ⚡ Bolt: Parallelize directory traversal and file stat retrieval.
+  // Previously, awaiting `handle.getFile()` sequentially caused O(N) latency.
+  // Collecting them into an array and using `Promise.all()` reduces this
+  // to approx O(N / concurrency) * latency, speeding up workspace loads significantly.
+  const promises = [];
   for await (const [name, handle] of dirHandle.entries()) {
     if (name.startsWith('.')) continue;
     if (handle.kind === 'directory') {
       if (name.toLowerCase() === ASSETS_DIR) continue;
-      await walk(handle, `${prefix}${name}/`, out);
+      promises.push(walk(handle, `${prefix}${name}/`, out));
     } else if (/\.(md|markdown)$/i.test(name)) {
-      let lastModified = 0, size = 0;
-      try {
-        const f = await handle.getFile();
-        lastModified = f.lastModified;
-        size = f.size;
-      } catch { /* unreadable entry; keep it listed */ }
-      out.push({
-        path: `${prefix}${name}`,
-        name,
-        title: name.replace(/\.(md|markdown)$/i, ''),
-        handle,
-        lastModified,
-        size,
-      });
+      promises.push((async () => {
+        let lastModified = 0, size = 0;
+        try {
+          const f = await handle.getFile();
+          lastModified = f.lastModified;
+          size = f.size;
+        } catch { /* unreadable entry; keep it listed */ }
+        out.push({
+          path: `${prefix}${name}`,
+          name,
+          title: name.replace(/\.(md|markdown)$/i, ''),
+          handle,
+          lastModified,
+          size,
+        });
+      })());
     }
   }
+  await Promise.all(promises);
 }
 
 /** Resolve a slash-separated relative path to a parent dir handle + basename. */


### PR DESCRIPTION
💡 What: Modifies the `walk` function in `js/fs.js` to collect `handle.getFile()` operations in an array and run them concurrently using `Promise.all()`.
🎯 Why: Iterating directories sequentially with asynchronous `handle.getFile()` calls resulted in an `O(N)` latency overhead as each operation blocks until the previous completes. In workspaces with many notes, this blocked main app rendering unnecessarily.
📊 Impact: Speeds up directory loading time by reducing iteration time to approx `O(N / concurrency) * latency` without sacrificing deterministic sorting downstream.
🔬 Measurement: Verify loading latency visually using a dummy directory with 500+ markdown files, observing lower wait time when first attaching the workspace.

---
*PR created automatically by Jules for task [2827321250769905124](https://jules.google.com/task/2827321250769905124) started by @mitchyc24*